### PR TITLE
Build container images on push to main branch

### DIFF
--- a/.github/workflows/build_main.yml
+++ b/.github/workflows/build_main.yml
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: build images
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  auth:
+    name: auth
+    uses: ./.github/workflows/_ghcr.yml
+    with:
+      ghcr_user: ${{github.actor}}
+      base_image_name: ghcr.io/hifis-net/rsd-saas/auth
+      image_tag: $GITHUB_SHA
+      dockerfile: authentication/Dockerfile
+      docker_context: ./authentication
+    secrets:
+      token: ${{secrets.GITHUB_TOKEN}}
+
+  database:
+    name: database
+    uses: ./.github/workflows/_ghcr.yml
+    with:
+      ghcr_user: ${{github.actor}}
+      base_image_name: ghcr.io/hifis-net/rsd-saas/database
+      image_tag: $GITHUB_SHA
+      dockerfile: database/Dockerfile
+      docker_context: ./database
+    secrets:
+      token: ${{secrets.GITHUB_TOKEN}}
+
+  backend:
+    name: backend api
+    uses: ./.github/workflows/_ghcr.yml
+    with:
+      ghcr_user: ${{github.actor}}
+      base_image_name: ghcr.io/hifis-net/rsd-saas/backend
+      image_tag: $GITHUB_SHA
+      dockerfile: backend-postgrest/Dockerfile
+      docker_context: ./backend-postgrest
+    secrets:
+      token: ${{secrets.GITHUB_TOKEN}}
+
+  frontend:
+    name: frontend
+    uses: ./.github/workflows/_ghcr.yml
+    with:
+      ghcr_user: ${{github.actor}}
+      base_image_name: ghcr.io/hifis-net/rsd-saas/frontend
+      image_tag: $GITHUB_SHA
+      dockerfile: frontend/Dockerfile
+      docker_context: ./frontend
+    secrets:
+      token: ${{secrets.GITHUB_TOKEN}}
+
+  nginx:
+    name: nginx
+    uses: ./.github/workflows/_ghcr.yml
+    with:
+      ghcr_user: ${{github.actor}}
+      base_image_name: ghcr.io/hifis-net/rsd-saas/nginx
+      image_tag: $GITHUB_SHA
+      dockerfile: nginx/Dockerfile
+      docker_context: ./nginx
+    secrets:
+      token: ${{secrets.GITHUB_TOKEN}}
+
+  scrapers:
+    name: scrapers
+    uses: ./.github/workflows/_ghcr.yml
+    with:
+      ghcr_user: ${{github.actor}}
+      base_image_name: ghcr.io/hifis-net/rsd-saas/scrapers
+      image_tag: $GITHUB_SHA
+      dockerfile: scrapers/Dockerfile
+      docker_context: ./scrapers
+    secrets:
+      token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
# Build container images on push to main branch

Fixes https://github.com/hifis-net/RSD-as-a-service/issues/12

Changes proposed in this pull request:

* adds gh actions workflow that will be triggered on push to main branch and builds & push container images  

How to test:

* n.a.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
