### PR TITLE
Ensure submodules are checked out in actions workflow

### DIFF
--- a/.github/workflows/_ghcr.yml
+++ b/.github/workflows/_ghcr.yml
@@ -50,6 +50,8 @@ jobs:
       - name: checkout
         # https://github.com/actions/checkout
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: build
         id: build_image
         run: |


### PR DESCRIPTION
Fixes failed frontend image build, see https://github.com/hifis-net/RSD-as-a-service/runs/7358769415?check_suite_focus=true

Changes proposed in this pull request:

* recursively checkout submodules when using the checkout action during image build workflow

How to test:

* n.n

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
