### PR TITLE
fix: show only centres with software contributions

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -521,7 +521,7 @@ async function getOrganisationsList({url, token}: {url: string, token?: string})
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const {req} = context
   const token = req?.cookies['rsd_token']
-  const url = `${process.env.POSTGREST_URL}/rpc/organisations_overview?parent=is.null`
+  const url = `${process.env.POSTGREST_URL}/rpc/organisations_overview?parent=is.null&software_cnt=gt.0`
   const {data} = await getOrganisationsList({url, token})
   return {
     props: {


### PR DESCRIPTION
Under "Contributions", we now list only centres that have software contributions in the RSD.

Fixes #31

How to test:

* perform the spotlight migration (optional)
* in a project or a software, add a related organisation that is not already in the database
* navigate to the frontpage and verify that the recently added organisation is not shown in the list
