### PR TITLE
minor: show bold text with highlighted background instead

### DIFF
--- a/deployment/helmholtz/styles/index.css
+++ b/deployment/helmholtz/styles/index.css
@@ -80,3 +80,9 @@ header input {
   z-index: 1;
   background-image: url("/images/pexels-olena-bohovyk-3646172.jpg");
 }
+
+p strong,
+p b {
+  font-weight: normal !important;
+  background-color:#cdeefb;
+}


### PR DESCRIPTION
# Show bold text with highlighted background instead

Fixes #30

Changes proposed in this pull request:

* instead of bold text we render texts with light blue background

How to test:

* add software including bold text (`**bold text**`) within the markdown content

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [X] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
